### PR TITLE
Mike tidy 2

### DIFF
--- a/Notebooks/Part_2_SMP_ETL.ipynb
+++ b/Notebooks/Part_2_SMP_ETL.ipynb
@@ -559,7 +559,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure6.png\" height=\"500px\"></center>\n",
     "\n",
-    "<center>Figure 6 of [Montpetit et al. (2024)](Link TBD): Results of calibrated SMP snow density measurements</center>"
+    "<center>Figure 6 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al. (2024)</a>: Results of calibrated SMP snow density measurements</center>"
    ]
   },
   {
@@ -720,7 +720,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure7.png\" height=\"500px\"></center>\n",
     "\n",
-    "<center>Figure 7 of [Montpetit et al. (2024)](Link TBD): Example of original vs scaled distance and calibrated SMP density vs pit density</center>"
+    "<center>Figure 7 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al. (2024)</a>: Example of original vs scaled distance and calibrated SMP density vs pit density</center>"
    ]
   },
   {

--- a/Notebooks/Part_3_GrainClassification.ipynb
+++ b/Notebooks/Part_3_GrainClassification.ipynb
@@ -17,7 +17,7 @@
     "- Only two snow types were used compared to three in [King et al. (2020)](https://tc.copernicus.org/articles/14/4323/2020/tc-14-4323-2020.pdf)\n",
     "- Snow types used: .Rounded grains (wind slab layer in Arctic Snowpacks)\n",
     "                   .Depth hoar layer\n",
-    "- Mixed/Faceted grain layers were reported by surveyors but were labelled as rounded grains for this classifier (see [Montpetit et al. (2024)](link TBD))"
+    "- Mixed/Faceted grain layers were reported by surveyors but were labelled as rounded grains for this classifier (see [Montpetit et al. (2024)](https://doi.org/10.5194/egusphere-2024-651))"
    ]
   },
   {
@@ -27,7 +27,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure3.png\" height=\"500px\" class=\"bg-primary mb-1\"></center>\n",
     "\n",
-    "<center>Figure 3 of [Montpetit et al. (2024)](Link TBD): Ground based snow measurements sampling scheme..</center>"
+    "<center>Figure 3 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al. (2024)</a>: Ground based snow measurements sampling scheme..</center>"
    ]
   },
   {
@@ -869,7 +869,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure9.png\" height=\"500px\"></center>\n",
     "\n",
-    "<center>Figure 9 of [Montpetit et al. (2024)](Link TBD): Distribution of snow density and SSA for the three dominant grain type layers for the January campaign.</center>"
+    "<center>Figure 9 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al. (2024)</a>: Distribution of snow density and SSA for the three dominant grain type layers for the January campaign.</center>"
    ]
   },
   {

--- a/Notebooks/Part_5_RepPitSelection.ipynb
+++ b/Notebooks/Part_5_RepPitSelection.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some discrepenties between the sites naming conventions were noted between the work of [Josh King](https://github.com/kingjml) and [Benoit Montpetit](https://github.com/ecccben). The site names were not changed in the files but the naming convention used here is the one found in [Montpetit et al. (2024)](Link TBD)\n"
+    "Some discrepencies between the sites naming conventions were noted between the work of [Josh King](https://github.com/kingjml) and [Benoit Montpetit](https://github.com/ecccben). The site names were not changed in the files but the naming convention used here is the one found in [Montpetit et al. (2024)](https://doi.org/10.5194/egusphere-2024-651)\n"
    ]
   },
   {
@@ -545,7 +545,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure5.png\" height=\"500px\" class=\"bg-primary mb-1\"></center>\n",
     "\n",
-    "<center>Figure 5 of [Montpetit et al. (2024)](Link TBD): Evolution of snow geophysical properties (SSA, density, and temperature) throughout the winter season for the two dominant snow\n",
+    "<center>Figure 5 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al. (2024)</a>: Evolution of snow geophysical properties (SSA, density, and temperature) throughout the winter season for the two dominant snow\n",
     "grain type layers: rounded (R) and depth hoar grains (H).</center>"
    ]
   },
@@ -588,7 +588,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure4.png\" height=\"500px\" class=\"bg-primary mb-1\"></center>\n",
     "\n",
-    "<center>Figure 4 of [Montpetit et al. (2024)](Link TBD): Evolution of snow depth distributions and depth hoar fraction throughout the field campaign.</center>"
+    "<center>Figure 4 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al. (2024)</a>: Evolution of snow depth distributions and depth hoar fraction throughout the field campaign.</center>"
    ]
   },
   {
@@ -809,7 +809,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example of the selected SMP profile snow depth compared to the snow depths of all SMP profiles and MagnaProbe distribution for the SM site (Table 2 of [Montpetit et al., 2024](Link TBD))"
+    "# Example of the selected SMP profile snow depth compared to the snow depths of all SMP profiles and MagnaProbe distribution for the SM site (Table 2 of [Montpetit et al., 2024](https://doi.org/10.5194/egusphere-2024-651))"
    ]
   },
   {
@@ -856,7 +856,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure8.png\" height=\"500px\" class=\"bg-primary mb-1\"></center>\n",
     "\n",
-    "<center>Figure 8 of [Montpetit et al. (2024)](Link TBD): Example of the SMP profile selection as a representative snowpack for the SM site (Table 2).</center>"
+    "<center>Figure 8 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al. (2024)</a>: Example of the SMP profile selection as a representative snowpack for the SM site (Table 2).</center>"
    ]
   }
  ],

--- a/Notebooks/Part_6_StatPitCreation.ipynb
+++ b/Notebooks/Part_6_StatPitCreation.ipynb
@@ -8,7 +8,7 @@
     "[Benoit Montpetit](https://github.com/ecccben), *CPS/CRD/ECCC*, 2024  \n",
     "[Mike Brady](https://github.com/m9brady), *CPS/CRD/ECCC*, 2024\n",
     "\n",
-    "Here we use all SMP profiles measured for a given snowpit and compute the median values of all the snow geophysical properties for the two main grain type layers (rounded grains and depth hoar grains). This is used in the discussion section of [Montpetit et al. (2024)](Link TBD) to show that using a two layer snowpack does not have a significant impact on the simulated backscatter at Ku-Band using SMRT."
+    "Here we use all SMP profiles measured for a given snowpit and compute the median values of all the snow geophysical properties for the two main grain type layers (rounded grains and depth hoar grains). This is used in the discussion section of [Montpetit et al. (2024)](https://doi.org/10.5194/egusphere-2024-651) to show that using a two layer snowpack does not have a significant impact on the simulated backscatter at Ku-Band using SMRT."
    ]
   },
   {

--- a/Notebooks/Part_6_StatPitCreation.ipynb
+++ b/Notebooks/Part_6_StatPitCreation.ipynb
@@ -72,15 +72,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pd.DataFrame(df_aggpits[site][profile])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "pit_stats = {}\n",
     "\n",
     "rho_ws = np.array([])\n",

--- a/Notebooks/Part_7_C+X-BandOptimization.ipynb
+++ b/Notebooks/Part_7_C+X-BandOptimization.ipynb
@@ -50,7 +50,7 @@
    "id": "9c23d127",
    "metadata": {},
    "source": [
-    "Extrapolation function of permittivity implemented in SMRT based on Montpetit et al. (2018)"
+    "Extrapolation function of permittivity implemented in SMRT based on [Montpetit et al. (2018)](https://doi.org/10.1016/j.rse.2017.10.033)"
    ]
   },
   {

--- a/Notebooks/Part_7_C+X-BandOptimization.ipynb
+++ b/Notebooks/Part_7_C+X-BandOptimization.ipynb
@@ -782,7 +782,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure10.png\" Width=\"1000px\"></center>\n",
     "\n",
-    "Figure 10 of [Montpetit et al., (2024)](link TBD): Distributions of the retrieved real $\\varepsilon_{soil}$ for C- and X-Band data for all the sites measured during the January campaign."
+    "Figure 10 of [Montpetit et al., (2024)](https://doi.org/10.5194/egusphere-2024-651): Distributions of the retrieved real $\\varepsilon_{soil}$ for C- and X-Band data for all the sites measured during the January campaign."
    ]
   },
   {
@@ -913,7 +913,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure11.png\" Width=\"1000px\"></center>\n",
     "\n",
-    "Figure 11 of [Montpetit et al., (2024)](link TBD): Comparison between simulated and measured $\\sigma^0$ at C- and X-Band for a) using a single set of parameters for all sites (’All’ in\n",
+    "Figure 11 of [Montpetit et al., (2024)](https://doi.org/10.5194/egusphere-2024-651): Comparison between simulated and measured $\\sigma^0$ at C- and X-Band for a) using a single set of parameters for all sites (’All’ in\n",
     "Table 6) and b) retrieved parameters for each site individually (distributed values shown in Figure 10)."
    ]
   }

--- a/Notebooks/Part_8_Ku-BandOptimization.ipynb
+++ b/Notebooks/Part_8_Ku-BandOptimization.ipynb
@@ -993,7 +993,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure12.png\" Width=\"1000px\"></center>\n",
     "\n",
-    "Figure 12 of [Montpetit et al., (2024)](link TBD): Distribution of retrieved parameters at Ku-Band (Table 7). The range of retrieved *K* values from [Picard et al. (2022)](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2021AV000630) for both\n",
+    "Figure 12 of [Montpetit et al., (2024)](https://doi.org/10.5194/egusphere-2024-651): Distribution of retrieved parameters at Ku-Band (Table 7). The range of retrieved *K* values from [Picard et al. (2022)](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2021AV000630) for both\n",
     "grain types (PG22) and the different values retrieved by [King et al. (2018)](https://www.sciencedirect.com/science/article/pii/S003442571830258X?via%3Dihub) and [Montpetit et al. (2013)](https://ieeexplore.ieee.org/document/6507560) are also displayed (KJ18 and MB13\n",
     "respectively)."
    ]
@@ -1261,7 +1261,7 @@
    "source": [
     "<center><img src=\"../Figures/Figure13.png\" Width=\"1000px\"></center>\n",
     "\n",
-    "Figure 13 of [Montpetit et al., (2024)](link TBD): Comparison between simulated and measured $\\sigma^0$ at Ku-Band for a) using a single set of parameters for all sites (Table 7), b)\n",
+    "Figure 13 of [Montpetit et al., (2024)](https://doi.org/10.5194/egusphere-2024-651): Comparison between simulated and measured $\\sigma^0$ at Ku-Band for a) using a single set of parameters for all sites (Table 7), b)\n",
     "retrieved parameters for each site individually (distributed values shown in Figure 12) and c) the same parameterization as a) except the\n",
     "median values of $\\varepsilon'_{soil}$ of the two clusters of Figure 12 were used. Color code corresponds to each surveyed site in January."
    ]
@@ -2047,7 +2047,7 @@
    "source": [
     "<center><img src=\"../Figures/Part_8_KuOpti_Fig1.png\" Width=\"1000px\"></center>\n",
     "\n",
-    "<center>Figure : Same as Figure 13 of [Montpetit et al., (2024)](link TBD) but with a 2 layer statistically representative snowpack.</center>"
+    "<center>Figure : Same as Figure 13 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al., (2024)</a> but with a 2 layer statistically representative snowpack.</center>"
    ]
   },
   {
@@ -2083,7 +2083,7 @@
    "source": [
     "<center><img src=\"../Figures/Part_8_KuOpti_Fig2.png\" Width=\"1000px\"></center>\n",
     "\n",
-    "<center>Figure : Same as Figure 12 of [Montpetit et al., (2024)](link TBD) but with a 2 layer statistically representative snowpack.</center>"
+    "<center>Figure : Same as Figure 12 of <a href=\"https://doi.org/10.5194/egusphere-2024-651\">Montpetit et al., (2024)</a> but with a 2 layer statistically representative snowpack.</center>"
    ]
   }
  ],

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ it becomes possible to properly characterize the snow and how it translates into
 </p>
 
 <p align="center">
-    <i>Figure 2 from [Montpetit et al. (2024)[Link TBD]: Flight lines completed during each of the TVC snow deployments (a). The 2016 vegetation classification map <a href="https://doi.pangaea.de/10.1594/PANGAEA.904270">Grunberg and Boïke (2019)</a> with the location of the surveyed sites and soil stations (b). The weather station is located at the SM site. The size of the surveyed sites box corresponds to the 100 m footprint of the radar data.</i>
+    <i>Figure 2 from <a href="https://doi.org/10.5194/egusphere-2024-651">Montpetit et al. (2024)</a>: Flight lines completed during each of the TVC snow deployments (a). The 2016 vegetation classification map <a href="https://doi.pangaea.de/10.1594/PANGAEA.904270">Grunberg and Boïke (2019)</a> with the location of the surveyed sites and soil stations (b). The weather station is located at the SM site. The size of the surveyed sites box corresponds to the 100 m footprint of the radar data.</i>
 </p>
 
 > **Warning**

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ it becomes possible to properly characterize the snow and how it translates into
 </p>
 
 > **Warning**
-> Access to RADARSAT-2 data products is not included with this repository. RADARSAT-2 Data and Products © MacDonald, Dettwiler and Associates Ltd. (2023) – All Rights Reserved. RADARSAT is an official mark of the Canadian Space Agency.
-> The TerraSAR-X data are available through the DLR (© DLR 2019).
+> Access to RADARSAT-2 data products is not included with this repository. RADARSAT-2 Data and Products © MacDonald, Dettwiler and Associates Ltd. (2023) – All Rights Reserved. RADARSAT is an official mark of the Canadian Space Agency. The TerraSAR-X data are available through the DLR (© DLR 2019).
 
 ## Ackowledgments
 
@@ -52,10 +51,11 @@ Use [miniconda](https://docs.conda.io/projects/miniconda/en/latest/), [mamba](ht
 
 
 ```
-conda env create -n smrt -f environment.yml
-conda activate smrt
+conda env create -n tvc1819 -f environment.yml
+conda activate tvc1819
 ```
-With the environment activated you can follow the installation instructions from [G. Picard](https://github.com/ghislainp) to install the latest stable SMRT release [SMRT](https://github.com/smrt-model/smrt)
+
+The `tvc1819` environment installs the Snow Microwave Radiative Transfer Model (SMRT) version 1.2.4 (released 2024/01/18). If you would like to use a more recent version, then with the environment activated you can follow the installation instructions from [G. Picard](https://github.com/ghislainp) to install the latest stable SMRT release: [SMRT install instructions](https://github.com/smrt-model/smrt?tab=readme-ov-file#quick-installation)
 
 > **Warning** 
 > The provided environment.yml file was generated on Windows 10 and may behave differently on Linux or Mac systems.
@@ -75,10 +75,10 @@ To download the datasets used by the notebooks, use the following links:
 - [Zenodo: TVC Experiment 2018/19: LiDAR processed soil roughness](https://doi.org/10.5281/zenodo.10794980)
   - `SoilRough_ALS2018_TVC18-19.json`
 - [Pangaea: Airborne Laser Scanning (ALS) Point Clouds of Trail Valley Creek, NWT, Canada (2018)](https://doi.pangaea.de/10.1594/PANGAEA.934387)
-  - `vegetation_map_TVC_2019.tif`
-- [Pangaea: Vegetation map of Trail Valley Creek, Northwest Territories, Canada.](https://doi.pangaea.de/10.1594/PANGAEA.904270)
   - `TVC_ALS_201808_DTM.tif`
   - `TVC_ALS_201808_VegetationHeight_Mean.tif`
+- [Pangaea: Vegetation map of Trail Valley Creek, Northwest Territories, Canada.](https://doi.pangaea.de/10.1594/PANGAEA.904270)
+  - `vegetation_map_TVC_2019.tif`
 
 and store the data as shown:
 
@@ -104,7 +104,7 @@ Data
 
 ## Exploring the Notebooks
 
-After setting up the environment and data, you may wish to look first at the Table of Contents in [the index notebook](./index.ipynb) to discover which parts of the code interest you. In order to launch the Table of Contents notebook on your local system, use the following command while inside the activated `smrt` environment:
+After setting up the environment and data, you may wish to look first at the Table of Contents in [the index notebook](./index.ipynb) to discover which parts of the code interest you. In order to launch the Table of Contents notebook on your local system, use the following command while inside the activated `tvc1819` environment:
 
 ```
 jupyter notebook index.ipynb

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: test
+name: tvc1819
 channels:
   - conda-forge
   - defaults
@@ -192,7 +192,7 @@ dependencies:
   - numpy=1.25.1=py311h0b4df5a_0
   - openjpeg=2.5.0=ha2aaf27_2
   - openpyxl=3.1.2=py311ha68e1ae_1
-  - openssl=3.2.1=hcfcfb64_0
+  - openssl=3.1.5=hcfcfb64_0
   - orc=1.7.4=h623e30f_1
   - overrides=7.3.1=pyhd8ed1ab_0
   - packaging=23.1=pyhd8ed1ab_0
@@ -311,6 +311,9 @@ dependencies:
   - zstd=1.5.2=h12be248_7
   - pip:
       - affine==2.4.0
+      - llvmlite==0.42.0
+      - numba==0.59.0
       - rasterio==1.3.9
+      - smrt==1.2.4
+      - snowmicropyn==1.2.1
       - snuggs==1.4.7
-prefix: C:\Users\MontpetitB\AppData\Local\anaconda3\envs\test


### PR DESCRIPTION
Second pass for repo
README
- fixed pangaea links (were reversed by accident)
- rename env from `smrt` to `tvc1819` to match environment.yml
- revise SMRT section to explain about installing more-recent smrt version (we already install it when creating conda env)

environment.yml
- rename env from `test` to `tvc1819`
- switch to openssl 3.15 because of conflicts with libpq during env creation
- remove un-needed prefix from environment.yml
- add pip-installed smrt to environment.yml
- add pip-installed snowmicropyn to environment.yml

notebooks
- update TBD links to preprint doi
- remove unused cell in Part6 `pd.DataFrame(df_aggpits[site][profile])`
- add link to Montpetit et al 2018 in Part 7 (@ECCCBen is this the right paper?): https://doi.org/10.1016/j.rse.2017.10.033
